### PR TITLE
API更改的问题修复

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,7 @@
 const
-  servers = "https://sr-api.sfirew.com/server/",
-  render = "https://visage.surgeplay.com/",
-  mojang = "https://api.mojang.com/";
+  servers = "https://sr-api.sfirew.com/server",
+  render = "https://visage.surgeplay.com",
+  mojang = "https://api.mojang.com";
 
 export interface MCUser {id: string, name: string}
 export async function getUser(username: string) : Promise<MCUser> {

--- a/src/api.ts
+++ b/src/api.ts
@@ -16,7 +16,7 @@ export function renderView(user: MCUser) {
     skinBust: `${render}/bust/${user.id}`,
     skinView: `${render}/full/${user.id}`,
     download: `${render}/processedskin/${user.id}`,
-    headView: `${render}/head/body/${user.id}`,
+    headView: `${render}/head/${user.id}`,
     headFace: `${render}/face/${user.id}`,
     gethead: {
       "new": `/give @p minecraft:player_head{SkullOwner:"${user.name}"}`,


### PR DESCRIPTION
首先不要在 URL 里出现多的斜杠，例如 `https://visage.surgeplay.com//head/df5ef102bcfb484ea1f0f9446625324f`，否则可能会被服务器认错。你可以试一下，这个链接也是加载不出来的，把中间两个连续的斜杠改成一个就加载出来了。

其次，渲染头用 `/head/<uuid>`，而不是 `/head/body/<uuid>`。